### PR TITLE
SCRUM-329: Generate matches for all courts given business and date

### DIFF
--- a/app/api/routes/matches.py
+++ b/app/api/routes/matches.py
@@ -12,7 +12,10 @@ from app.models.match import (
     MatchUpdate,
 )
 from app.models.match_extended import MatchesExtendedListPublic
-from app.models.match_generation import MatchGenerationCreate
+from app.models.match_generation import (
+    MatchGenerationCreate,
+    MatchGenerationCreateExtended,
+)
 from app.services.match_generator_service import MatchGeneratorService
 from app.services.match_service import MatchService
 from app.utilities.dependencies import SessionDep
@@ -54,12 +57,35 @@ async def create_matches(
     status_code=status.HTTP_201_CREATED,
 )
 async def generate_matches(
+    *, session: SessionDep, match_gen_create: MatchGenerationCreateExtended
+) -> Any:
+    """
+    Generate matches given business, court and date
+    """
+    match_gen_service = MatchGeneratorService()
+    matches_public_ids = await match_gen_service.generate_matches(
+        session, match_gen_create
+    )
+    matches = await match_gen_service.get_matches(session, matches_public_ids)
+    return MatchesExtendedListPublic.from_private(matches)
+
+
+@router.post(
+    "/generation/all",
+    response_model=MatchesExtendedListPublic,
+    status_code=status.HTTP_201_CREATED,
+)
+async def generate_matches_all(
     *, session: SessionDep, match_gen_create: MatchGenerationCreate
 ) -> Any:
     """
     Generate matches given business, court and date
     """
-    matches = await MatchGeneratorService().generate_matches(session, match_gen_create)
+    match_gen_service = MatchGeneratorService()
+    matches_public_ids = await match_gen_service.generate_matches_all(
+        session, match_gen_create
+    )
+    matches = await match_gen_service.get_matches(session, matches_public_ids)
     return MatchesExtendedListPublic.from_private(matches)
 
 

--- a/app/models/court.py
+++ b/app/models/court.py
@@ -1,0 +1,10 @@
+from uuid import UUID
+
+from sqlmodel import Field, SQLModel
+
+
+class Court(SQLModel):
+    business_public_id: UUID = Field()
+    court_public_id: UUID = Field()
+    court_name: str = Field()
+    price_per_hour: float = Field()

--- a/app/models/match_generation.py
+++ b/app/models/match_generation.py
@@ -6,5 +6,8 @@ from sqlmodel import Field, SQLModel
 
 class MatchGenerationCreate(SQLModel):
     business_public_id: uuid.UUID = Field()
-    court_name: str = Field()
     date: datetime.date = Field()
+
+
+class MatchGenerationCreateExtended(MatchGenerationCreate):
+    court_name: str = Field()

--- a/app/services/business_service.py
+++ b/app/services/business_service.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from app.core.config import settings
 from app.models.available_time import AvailableTime
+from app.models.court import Court
 
 from .base_service import BaseService
 
@@ -19,6 +20,25 @@ class BusinessService(BaseService):
         )
         if settings.BUSINESS_SERVICE_API_KEY:
             self.set_base_headers({"x-api-key": settings.BUSINESS_SERVICE_API_KEY})
+
+    async def get_courts(self, business_public_id: uuid.UUID) -> list[Court]:
+        content = await self.get("/api/v1/padel-courts/")
+        data = content["data"]
+        business_data = []
+        for datum in data:
+            if datum["business_public_id"] == str(business_public_id):
+                business_data.append(datum)
+
+        courts = []
+        for datum in business_data:
+            avail_time = Court(
+                business_public_id=datum["business_public_id"],
+                court_public_id=datum["court_public_id"],
+                court_name=datum["court_name"],
+                price_per_hour=datum["price_per_hour"],
+            )
+            courts.append(avail_time)
+        return courts
 
     async def get_available_times(
         self, business_public_id: uuid.UUID, court_name: str, date: date

--- a/app/tests/api/routes/test_matches_generation.py
+++ b/app/tests/api/routes/test_matches_generation.py
@@ -21,8 +21,8 @@ async def test_generate_matches_given_one_avail_time(
     times = [9]
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_name": "1",
-        "court_public_id": str(uuid.uuid4()),
+        "court_names": ["1"],
+        "court_public_ids": [str(uuid.uuid4())],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -37,11 +37,8 @@ async def test_generate_matches_given_one_avail_time(
     )
 
     # Main request
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
     response = await async_client.post(
         f"{test_settings.API_V1_STR}/matches/generation",
         headers=x_api_key_header,
@@ -56,8 +53,9 @@ async def test_generate_matches_given_one_avail_time(
     assert len(matches) == 1
 
     match_extended = matches[0]
-    for k in ["court_public_id", "court_name", "date"]:
-        assert match_extended[k] == test_data[k]
+    for k in ["court_public_id", "court_name"]:
+        assert match_extended[k] in test_data[f"{k}s"]  # type: ignore
+    assert match_extended["date"] == test_data["date"]
     assert match_extended["time"] == test_data["times"][0]  # type: ignore
     match_time = match_extended["time"]
     time_avail = PlayerFilters.to_time_availability(match_time)
@@ -96,8 +94,8 @@ async def test_generate_matches_given_three_avail_time(
     times = [8, 9, 10]
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_name": "1",
-        "court_public_id": str(uuid.uuid4()),
+        "court_names": ["1"],
+        "court_public_ids": [str(uuid.uuid4())],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -112,11 +110,8 @@ async def test_generate_matches_given_three_avail_time(
     )
 
     # Main request
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
 
     response = await async_client.post(
         f"{test_settings.API_V1_STR}/matches/generation",
@@ -132,8 +127,9 @@ async def test_generate_matches_given_three_avail_time(
     assert len(matches) == 3
 
     for match_extended in matches:
-        for k in ["court_public_id", "court_name", "date"]:
-            assert match_extended[k] == test_data[k]
+        for k in ["court_public_id", "court_name"]:
+            assert match_extended[k] in test_data[f"{k}s"]  # type: ignore
+        assert match_extended["date"] == test_data["date"]
         time = match_extended["time"]
         time_avail = PlayerFilters.to_time_availability(time)
         assigned_player = assigned_players[time_avail]["assigned"]
@@ -172,8 +168,8 @@ async def test_generate_matches_twice_for_the_same_day_and_same_times(
     times = [8, 9, 10]
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_name": "1",
-        "court_public_id": str(uuid.uuid4()),
+        "court_names": ["1"],
+        "court_public_ids": [str(uuid.uuid4())],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -185,11 +181,8 @@ async def test_generate_matches_twice_for_the_same_day_and_same_times(
 
     _ = initial_apply_mocks_for_generate_matches(monkeypatch, **test_data)
 
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
     response = await async_client.post(
         f"{test_settings.API_V1_STR}/matches/generation",
         headers=x_api_key_header,
@@ -222,8 +215,8 @@ async def test_generate_matches_twice_for_the_same_day_and_new_times(
     new_times = [6, 7, 8, 9, 10, 11, 12]
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_name": "1",
-        "court_public_id": str(uuid.uuid4()),
+        "court_names": ["1"],
+        "court_public_ids": [str(uuid.uuid4())],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -237,11 +230,8 @@ async def test_generate_matches_twice_for_the_same_day_and_new_times(
         monkeypatch, **test_data
     )
     # Main request
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
     response = await async_client.post(
         f"{test_settings.API_V1_STR}/matches/generation",
         headers=x_api_key_header,
@@ -277,8 +267,9 @@ async def test_generate_matches_twice_for_the_same_day_and_new_times(
     new_matches = new_matches_list["data"]
     assert len(new_matches) == 4
     for match_extended in new_matches:
-        for k in ["court_public_id", "court_name", "date"]:
-            assert match_extended[k] == test_data[k]
+        for k in ["court_public_id", "court_name"]:
+            assert match_extended[k] in test_data[f"{k}s"]  # type: ignore
+        assert match_extended["date"] == test_data["date"]
         assert match_extended["time"] in diff_times
         time = match_extended["time"]
         time_avail = PlayerFilters.to_time_availability(time)
@@ -319,8 +310,8 @@ async def test_generate_matches_for_the_same_with_new_times_twice(
     new_times = [6, 7, 8, 9, 10, 11, 12]
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_public_id": str(uuid.uuid4()),
-        "court_name": "1",
+        "court_public_ids": [str(uuid.uuid4())],
+        "court_names": ["1"],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -332,11 +323,8 @@ async def test_generate_matches_for_the_same_with_new_times_twice(
 
     _ = initial_apply_mocks_for_generate_matches(monkeypatch, **test_data)
 
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
     response = await async_client.post(
         f"{test_settings.API_V1_STR}/matches/generation",
         headers=x_api_key_header,
@@ -387,8 +375,8 @@ async def test_generate_matches_multiple_for_the_same_day(
     # Test ctes
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_public_id": str(uuid.uuid4()),
-        "court_name": "1",
+        "court_public_ids": [str(uuid.uuid4())],
+        "court_names": ["1"],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -402,11 +390,8 @@ async def test_generate_matches_multiple_for_the_same_day(
         monkeypatch, **test_data
     )
     # Main request
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
     response = await async_client.post(
         f"{test_settings.API_V1_STR}/matches/generation",
         headers=x_api_key_header,
@@ -440,8 +425,9 @@ async def test_generate_matches_multiple_for_the_same_day(
         new_matches = new_matches_list["data"]
         assert len(new_matches) == 1
         match_extended = new_matches[0]
-        for k in ["court_public_id", "court_name", "date"]:
-            assert match_extended[k] == test_data[k]
+        for k in ["court_public_id", "court_name"]:
+            assert match_extended[k] in test_data[f"{k}s"]  # type: ignore
+        assert match_extended["date"] == test_data["date"]
         assert match_extended["time"] == new_hour
         time = match_extended["time"]
         time_avail = PlayerFilters.to_time_availability(time)
@@ -480,8 +466,8 @@ async def test_generate_matches_multiple_for_the_same_day_inverse_time(
     # Test ctes
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_public_id": str(uuid.uuid4()),
-        "court_name": "1",
+        "court_public_ids": [str(uuid.uuid4())],
+        "court_names": ["1"],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -494,11 +480,8 @@ async def test_generate_matches_multiple_for_the_same_day_inverse_time(
         monkeypatch, **test_data
     )
     # Main request
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
     response = await async_client.post(
         f"{test_settings.API_V1_STR}/matches/generation",
         headers=x_api_key_header,
@@ -532,8 +515,9 @@ async def test_generate_matches_multiple_for_the_same_day_inverse_time(
         new_matches = new_matches_list["data"]
         assert len(new_matches) == 1
         match_extended = new_matches[0]
-        for k in ["court_public_id", "court_name", "date"]:
-            assert match_extended[k] == test_data[k]
+        for k in ["court_public_id", "court_name"]:
+            assert match_extended[k] in test_data[f"{k}s"]  # type: ignore
+        assert match_extended["date"] == test_data["date"]
         assert match_extended["time"] == new_hour
         time = match_extended["time"]
         time_avail = PlayerFilters.to_time_availability(time)
@@ -573,8 +557,8 @@ async def test_generate_matches_creates_match_players_with_distance_equal_to_arr
     times = [9]
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_public_id": str(uuid.uuid4()),
-        "court_name": "1",
+        "court_public_ids": [str(uuid.uuid4())],
+        "court_names": ["1"],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -588,11 +572,8 @@ async def test_generate_matches_creates_match_players_with_distance_equal_to_arr
     )
 
     # Main request
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
     response = await async_client.post(
         f"{test_settings.API_V1_STR}/matches/generation",
         headers=x_api_key_header,
@@ -607,8 +588,9 @@ async def test_generate_matches_creates_match_players_with_distance_equal_to_arr
     assert len(matches) == 1
 
     match_extended = matches[0]
-    for k in ["court_public_id", "court_name", "date"]:
-        assert match_extended[k] == test_data[k]
+    for k in ["court_public_id", "court_name"]:
+        assert match_extended[k] in test_data[f"{k}s"]  # type: ignore
+    assert match_extended["date"] == test_data["date"]
 
     assert match_extended["time"] == test_data["times"][0]  # type: ignore
     time = match_extended["time"]

--- a/app/tests/api/routes/test_matches_generation_all.py
+++ b/app/tests/api/routes/test_matches_generation_all.py
@@ -1,0 +1,84 @@
+import uuid
+from typing import Any
+
+from httpx import AsyncClient
+
+from app.core.config import test_settings
+from app.models.match_player import ReserveStatus
+from app.models.player import PlayerFilters
+from app.tests.utils.utils import (
+    initial_apply_mocks_for_generate_matches,
+)
+
+
+async def test_generate_matches_given_business_and_date_creates_for_each_court(
+    async_client: AsyncClient, x_api_key_header: dict[str, str], monkeypatch: Any
+) -> None:
+    n_courts = 3
+    times = [8, 9, 10]
+    test_data = {
+        "business_public_id": str(uuid.uuid4()),
+        "court_names": [f"Court {i}" for i in range(n_courts)],
+        "court_public_ids": [str(uuid.uuid4()) for _ in range(n_courts)],
+        "latitude": 0.0,
+        "longitude": 0.0,
+        "date": "2025-03-19",
+        "times": times,
+        "all_times": times,
+        "is_reserved": False,
+        "n_similar_players": 6,
+    }
+
+    assigned_players = initial_apply_mocks_for_generate_matches(
+        monkeypatch, **test_data
+    )
+
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+
+    response = await async_client.post(
+        f"{test_settings.API_V1_STR}/matches/generation/all",
+        headers=x_api_key_header,
+        json=data,
+    )
+
+    # Assertions
+    assert response.status_code == 201
+
+    matches_list = response.json()
+    matches = matches_list["data"]
+    assert len(matches) == (n_courts * len(times))
+
+    for match_extended in matches:
+        for k in ["court_public_id", "court_name"]:
+            assert match_extended[k] in test_data[f"{k}s"]  # type: ignore
+        assert match_extended["date"] == test_data["date"]
+        time = match_extended["time"]
+        time_avail = PlayerFilters.to_time_availability(time)
+        assigned_player = assigned_players[time_avail]["assigned"]
+        similar_players = assigned_players[time_avail]["similar"]
+        similar_players_user_public_ids = [
+            str(player.user_public_id) for player in similar_players
+        ]
+
+        # Should be one ASSIGNED player
+        match_players = match_extended["match_players"]
+        match_assigned_players = [
+            player
+            for player in match_players
+            if player["reserve"] == ReserveStatus.ASSIGNED
+        ]
+        assert len(match_assigned_players) == 1
+        match_assigned_player = match_assigned_players[0]
+        assert match_assigned_player["user_public_id"] == str(
+            assigned_player.user_public_id
+        )
+
+        # Should be N SIMILAR players
+        match_similar_players_user_public_ids = [
+            player["user_public_id"]
+            for player in match_players
+            if player["reserve"] == ReserveStatus.SIMILAR
+        ]
+        assert set(match_similar_players_user_public_ids) == set(
+            similar_players_user_public_ids
+        )

--- a/app/tests/services/test_match_generator_service.py
+++ b/app/tests/services/test_match_generator_service.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models.match_generation import MatchGenerationCreate
+from app.models.match_generation import MatchGenerationCreateExtended
 from app.services.business_service import BusinessService
 from app.services.match_generator_service import MatchGeneratorService
 from app.tests.utils.utils import (
@@ -20,8 +20,8 @@ async def test_generate_matches_twice_for_the_same_day_and_same_times(
     times = [8, 9, 10]
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_name": "1",
-        "court_public_id": str(uuid.uuid4()),
+        "court_names": ["1"],
+        "court_public_ids": [str(uuid.uuid4())],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -34,12 +34,9 @@ async def test_generate_matches_twice_for_the_same_day_and_same_times(
     _ = initial_apply_mocks_for_generate_matches(monkeypatch, **test_data)
 
     # Main request
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
-    match_gen_create = MatchGenerationCreate(**data)
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
+    match_gen_create = MatchGenerationCreateExtended(**data)
     service = MatchGeneratorService()
 
     response = await service.generate_matches(session, match_gen_create)
@@ -63,8 +60,8 @@ async def test_generate_matches_for_the_same_with_new_times_twice(
     new_times = [6, 7, 8, 9, 10, 11, 12, 13, 14]
     test_data = {
         "business_public_id": str(uuid.uuid4()),
-        "court_name": "1",
-        "court_public_id": str(uuid.uuid4()),
+        "court_names": ["1"],
+        "court_public_ids": [str(uuid.uuid4())],
         "latitude": 0.0,
         "longitude": 0.0,
         "date": "2025-03-19",
@@ -77,12 +74,9 @@ async def test_generate_matches_for_the_same_with_new_times_twice(
     _ = initial_apply_mocks_for_generate_matches(monkeypatch, **test_data)
     # Main request
     service = MatchGeneratorService()
-    data = {
-        k: v
-        for k, v in test_data.items()
-        if k in ["business_public_id", "court_name", "date"]
-    }
-    match_gen_create = MatchGenerationCreate(**data)
+    data = {k: v for k, v in test_data.items() if k in ["business_public_id", "date"]}
+    data["court_name"] = test_data["court_names"][0]  # type: ignore
+    match_gen_create = MatchGenerationCreateExtended(**data)
     response = await service.generate_matches(session, match_gen_create)
 
     assert len(response) == 5
@@ -95,7 +89,7 @@ async def test_generate_matches_for_the_same_with_new_times_twice(
         BusinessService, "get_available_times", mock_get_available_times_new
     )
 
-    match_gen_create_new = MatchGenerationCreate(**data)
+    match_gen_create_new = MatchGenerationCreateExtended(**data)
     response_for_new_generate = await service.generate_matches(
         session, match_gen_create_new
     )


### PR DESCRIPTION
Basarse en la https://tpii-padel-pals.atlassian.net/browse/SCRUM-295 para generar matches para todas las canchas de un establecimientos en particular.

Establecer un diagrama de flujo entre microservicios.

Se espera que al ejecutar el endpoint
- Para cada cancha del business crear matches
- Se creara un nuevo endpoint (equivalente al match/generate) agregar el all al final “generate/all”
